### PR TITLE
use repo token for checkout

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -21,6 +21,8 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        token: ${{ inputs.repo-token }}
 
     - name: Get current version
       id: get_current_version

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -21,8 +21,6 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        token: ${{ inputs.repo-token }}
 
     - name: Get current version
       id: get_current_version
@@ -93,6 +91,7 @@ runs:
       uses: actions/checkout@v4
       with:
         ref: "release/${{ steps.upgrade-version-id.outputs.version }}"
+        token: ${{ inputs.repo-token }}
       env:
         GITHUB_TOKEN: ${{ inputs.repo-token }}
 


### PR DESCRIPTION
This PR allows the use of the passed token to checkout the repo.
This allows to fix the push of the version bump and the start of the subsequents workflows if there are any since the github token does not allow that.