### PR TITLE
Variablise version file path

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: The GitHub token used to create release
     required: false
     default: ${{ github.token }}
+  version-file-path:
+    description: Optional version file path
+    default: "VERSION"
+    required: false
 
 outputs:
   version:
@@ -24,7 +28,7 @@ runs:
 
     - name: Get current version
       id: get_current_version
-      run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+      run: echo "version=$(cat ${{ inputs.version-file-path }})" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get version to upgrade to

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -21,6 +21,8 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        token: ${{ inputs.repo-token }}
 
     - name: Get current version
       id: get_current_version

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -21,8 +21,6 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        token: ${{ inputs.repo-token }}
 
     - name: Get current version
       id: get_current_version
@@ -93,6 +91,7 @@ runs:
       uses: actions/checkout@v4
       with:
         ref: "release/${{ steps.upgrade-version-id.outputs.version }}"
+        token: ${{ inputs.repo-token }}
       env:
         GITHUB_TOKEN: ${{ inputs.repo-token }}
 


### PR DESCRIPTION
This PR aims at variablizing the version file path. This is useful for project where the VERSIOn file is not at the root level or is not name VERSION.

The input is optional and will default to the previous behavior. This is not a breaking change.